### PR TITLE
message/sendToFriendアクションでバリデーション時にエラーとなった場合もメールが送信される不具合を修正

### DIFF
--- a/config/opAction2MailPluginConfiguration.class.php
+++ b/config/opAction2MailPluginConfiguration.class.php
@@ -72,7 +72,8 @@ EOF;
 メッセージに返信するには、こちらをクリックしてください。
 {$url}message
 EOF;
-    if(!$action->getRequestParameter('is_draft')){
+    $isMessageSent = isset($action->message) ? $action->message->is_send : false;
+    if($isMessageSent){
       self::notifyMail($member_to,$message);
     }
   }


### PR DESCRIPTION
メッセージが相手に到達しない「下書き」の場合とエラーの場合はいずれもメール通知を行うべきではないため、下記の条件を全て満たす場合のみメール送信を行うように修正しました。
- `$action->message` がセットされていること
  - バリデーションエラー時には `$action->message` はセットされない
- `$action->message->is_send` が true であること
  - 「下書き」作成時は false になる
